### PR TITLE
Added docker files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:alpine AS builder
+
+WORKDIR /spritematex
+
+COPY package.json package-lock.json ./
+
+RUN npm install
+
+COPY . .
+
+RUN npm run build
+
+#----
+
+FROM busybox:stable AS runner
+
+WORKDIR /
+
+EXPOSE 8080
+
+COPY --from=builder /spritematex/dist /spritematex
+
+CMD ["busybox", "httpd", "-f", "-v", "-p", "8080"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  spritematex-dockerfile:
+    container_name: "spritematex"
+    build: .
+    ports:
+      - "8080:8080"
+
+  # spritematex:
+  #   container_name: "spritematex"
+  #   image: oldskoolcoder/spritematex:latest
+  #   ports:
+  #     - "8080:8080"


### PR DESCRIPTION
`Dockerfile` runs npm build inside the container using the node:alpine image.

The `/spritematex/dist` folder is then taken from the builder stage and used in the runner stage as `/spritematex`

The Docker image can be built using:

`docker build -t spritematex .`

You can either run using Docker itself, or via Docker Compose.

`docker run -d --rm -p 8080:8080 --name spritematex-container spritematex`

The `docker-compose.yml` file can run the image either from the Dockerfile (via build) or from DockerHub (although the image will need to be pushed to your DockerHub account first)

`docker compose up`

SpritemateX is run using BusyBox, so there's no need to configure anything like nginx configs.

Once running, visit http://localhost:8080/spritematex/